### PR TITLE
feature: escapeHTML method as option

### DIFF
--- a/js/jquery.select-multiple.js
+++ b/js/jquery.select-multiple.js
@@ -84,6 +84,10 @@
           attributes = "",
           $option = $(option);
 
+      if (typeof that.options.escapeHTML === 'function') {
+        that.escapeHTML = that.options.escapeHTML;
+      }
+
       for (var cpt = 0; cpt < option.attributes.length; cpt++){
         var attr = option.attributes[cpt];
 


### PR DESCRIPTION
Hi,

I wanted to show some information (e.g percentages) on the right side of each element. Like in this screenshot:

![image](https://cloud.githubusercontent.com/assets/943430/15668314/9554721c-2755-11e6-9521-0824fbfbba6b.png)

Problem is, you are calling escapeHTML() on every element which is itself calling text(). So all my html is stripped. That makes it impossible to have more complicated li elements.
By making the escapeHTML method available as an option I can override it easily and make this possible.
Maybe simply giving an option to not escape the HTML is another possibility we could implement.
