### PR TITLE
feature: allow html in list

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,6 +59,7 @@ $('#my-select').selectMultiple()
 | selectableOptgroup | Boolean   | false                 | Click on optgroup will select all nested options when set to true.   |
 | dblClick           | Boolean   | false                 | Replace the defautl click event to select items by the dblclick one. |
 | cssClass           | String    | ""                    | Add a custom CSS class to the selectmultiple container.              |
+| allowHTML          | Boolean   | false                 | Don't escape items' HTML                                             |
 
 ### Methods
 

--- a/js/jquery.select-multiple.js
+++ b/js/jquery.select-multiple.js
@@ -91,7 +91,7 @@
           attributes += attr.name+'="'+attr.value+'" ';
         }
       }
-      var selectableLi = $('<li '+attributes+'><span>'+that.escapeHTML($option.text())+'</span><span class="pull-right ms-elem-selected">✔</span></li>'),
+      var selectableLi = $('<li '+attributes+'><span>'+(that.options.allowHTML === true ? $option.text() : that.escapeHTML($option.text()))+'</span><span class="pull-right ms-elem-selected">✔</span></li>'),
           selectedLi = selectableLi.clone(),
           value = $option.val(),
           elementId = that.sanitize(value);


### PR DESCRIPTION
Hi,

I wanted to show some information (e.g percentages) on the right side of each element. Like in this screenshot:

![image](https://cloud.githubusercontent.com/assets/943430/15668314/9554721c-2755-11e6-9521-0824fbfbba6b.png)

Problem is, you are calling escapeHTML() on every element which is itself calling text(). So all my html is stripped. That makes it impossible to have more complicated li elements.
By giving a new option allowHTML I can prevent that behavior easily and make this possible.
